### PR TITLE
Allow null value in yValues data

### DIFF
--- a/android/src/main/java/com/github/reactNativeMPAndroidChart/charts/ChartBaseManager.java
+++ b/android/src/main/java/com/github/reactNativeMPAndroidChart/charts/ChartBaseManager.java
@@ -359,8 +359,10 @@ public abstract class ChartBaseManager<T extends Chart, U extends Entry> extends
     ArrayList<U> createEntries(ReadableArray yValues) {
         ArrayList<U> entries = new ArrayList<>(yValues.size());
         for (int j = 0; j < yValues.size(); j++) {
-            entries.add(createEntry(yValues, j));
-        }
+	    if (!yValues.isNull(j)) {
+		entries.add(createEntry(yValues, j));
+	    }
+	}
         return entries;
     }
 


### PR DESCRIPTION
If there is null values in yValues array, the graph do the link
between known values around null values.
This allow to have a graph with a gap between two datasets:
a first dataset with the following yValues:
[1, 2, null, null, null]
The second with the following yValues:
[null, null, null, 4, 5]
